### PR TITLE
Define a font stack in report css styling

### DIFF
--- a/data/report_templates.sql
+++ b/data/report_templates.sql
@@ -3,8 +3,9 @@
 INSERT INTO report_static(static_name, static_text)
 VALUES
 ('css1',
+  '* {font-family: Century Gothic, CenturyGothic, AppleGothic, sans-serif;} '
   'table, th, td {border: 1px solid black; border-collapse: collapse; padding:4px;} '
-  'table tr td.value, table tr td.mono {font-family: Monospace;} '
+  'table tr td.value, table tr td.mono {font-family: consolas, monaco, Monospace;} '
   'table tr td.value {text-align: right;} '
   'table p {margin: 0.2em;}'
   'table tr.parent td:not(.hdr) {background-color: #D8E8C2;} '
@@ -34,8 +35,9 @@ VALUES
   '<h2>Report sections</h2>'
   '{report:toc}{report:sect}</body></html>'),
 ('css2',
+  '* {font-family: Century Gothic, CenturyGothic, AppleGothic, sans-serif;} '
   'table, th, td {border: 1px solid black; border-collapse: collapse; padding: 4px;} '
-  'table .value, table .mono {font-family: Monospace;} '
+  'table .value, table .mono {font-family: consolas, monaco, Monospace;} '
   'table .value {text-align: right;} '
   'table p {margin: 0.2em;}'
   '.int1 td:not(.hdr), td.int1 {background-color: #FFEEEE;} '


### PR DESCRIPTION
One of the main reason why the reports look a bit rough is that they use the browser default fonts, which a lot of people associate with unstyled content. Changing to a (web-safe) font stack gives it a somewhat nicer look, and in particular makes it look non-default.

Other people may have much better input on the specific font stack to use of course, but Century gothic is a decent default font and Consolas should be a good monospaced font to go with it.